### PR TITLE
(Readme) Add detailed env-var instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ pip install -r requirements.txt
 
 ## Usage
 
-You need to have an openai api key and set it as the environment variable 'OPENAI_API_KEY'.
+You need to have an openai api key and set it as the environment variable 'OPENAI_API_KEY':
 
 ```bash
+export OPENAI_API_KEY="Your_API_Key_Here"
 python main-local.py
 ```
 


### PR DESCRIPTION
If applied, this patch with update the Readme to show users how to properly export the `OPEN_API_KEY` env var when running `main-local.py`.

This solves the cause of issue #15  - Confusion about env vars.

I spoke with author of #15. They had not exported the env var properly:
- User believed the error message was caused by not having enough VRAM to run OpenAI APIs in "offline mode"
- I explained that "offline mode" means that `main-local.py` runs a flask server locally, but still depends on external OpenAI APIs
- I instructed user on setting Env Vars
- We verified that `main-local.py` runs after setting the env var

No breaking changes